### PR TITLE
프로필 이미지 용량 제한 삭제

### DIFF
--- a/src/components/user/ProfileEdit.tsx
+++ b/src/components/user/ProfileEdit.tsx
@@ -44,7 +44,6 @@ const ProfileEdit = ({
       reader.readAsDataURL(file);
       reader.onloadend = () => {
         const changeImg = reader.result;
-        localStorage.setItem("imgURL", changeImg as any);
         setImg(changeImg as any);
       };
     }
@@ -53,7 +52,7 @@ const ProfileEdit = ({
   const profileEdit = async () => {
     const imgRef = ref(storage, `${authService.currentUser?.uid}${Date.now()}`);
 
-    const imgDataUrl = localStorage.getItem("imgURL");
+    const imgDataUrl = img;
     let downloadUrl;
     if (imgDataUrl) {
       const response = await uploadString(imgRef, imgDataUrl, "data_url");
@@ -64,8 +63,6 @@ const ProfileEdit = ({
       photoURL: downloadUrl ? downloadUrl : null,
     })
       .then(() => {
-        localStorage.setItem("User", JSON.stringify(authService.currentUser));
-        localStorage.removeItem("imgURL");
         alert("프로필 수정을 완료했습니다");
         setModal(false);
         navigate("/user/:id");


### PR DESCRIPTION
### PR 타입
- 기능 수정

### 반영 브랜치
fix/profileEdit => dev

### 변경 사항
- localstorage에 저장했다가 프로필 수정하면 이미지 용량 제한이 있어서 localstorage 코드 부분을 삭제했습니다
- localstorage에 저장하는 대신 바로 firebase에 저장된 img를 불러왔습니다
- 코드 수정한 결과 이미지 용량 제한이 없습니다 (로딩이 느릴 수는 있습니다)