### PR TITLE
ui: 글쓰기 & 수정 & 상세페이지 수정

### DIFF
--- a/src/components/common/MobileCourseToggleBtn.tsx
+++ b/src/components/common/MobileCourseToggleBtn.tsx
@@ -6,7 +6,7 @@ const MobileCourseToggleBtn = ({ lists, openCourse, setOpenCourse }: any) => {
       {lists.length > 0 ? (
         <button
           onClick={() => setOpenCourse(!openCourse)}
-          className="lg:hidden 3xl:hidden w-full h-14 border border-gray-03 mb-5 text-[20px] font-bold px-4"
+          className="lg:hidden 3xl:hidden w-full h-16 border border-gray-03 mb-5 text-[18px] font-bold px-4"
         >
           <div className="lg:hidden 3xl:hidden flex justify-between items-center">
             {openCourse ? (

--- a/src/components/common/PostInfo.tsx
+++ b/src/components/common/PostInfo.tsx
@@ -63,26 +63,28 @@ const PostInfo = ({
   };
 
   return (
-    <div className="h-[220px] sm:h-[450px] md:h-[700px]  xs:h-[220px] text-white">
-      <img
-        src={
-          (uploadCover || galleryCover) !== undefined
-            ? uploadCover || galleryCover
-            : ""
-        }
-        className="w-full h-[220px] sm:h-[450px] md:h-[700px]  xs:h-[220px] object-cover z-0"
-      />
+    <div className="h-[220px] sm:h-[450px] md:h-[700px] xs:h-[220px] text-white">
+      {uploadCover || galleryCover ? (
+        <img
+          src={uploadCover || galleryCover}
+          className="w-full h-[220px] sm:h-[450px] md:h-[700px]  xs:h-[220px] object-cover z-0"
+        />
+      ) : (
+        <div className="w-full h-[220px] sm:h-[450px] md:h-[700px]  xs:h-[220px] object-cover z-0" />
+      )}
       <div className="w-full h-[220px] sm:h-[450px] md:h-[700px] -mt-[220px] sm:-mt-[450px] md:-mt-[700px] absolute z-10 bg-gradient-to-t from-[#00000060]" />
-      <div className="w-[85%] md:w-[70%] pt-28 m-auto -mt-[270px] sm:-mt-[300px] xs:w-[90%] xs:pt-40">
-        {/* {uploadCover === "" && galleryCover === "" ? (
-          <div className="scale-[0.25] sm:scale-50 md:scale-100 sm:top-[40%] md:top-[50%] left-[50%] xs:top-[67%] -translate-x-1/2  -translate-y-[250px] xs:-translate-y-[550px] absolute z-10">
+      <div className="w-full h-[220px] sm:h-[450px] md:h-[700px] -mt-[220px] sm:-mt-[450px] md:-mt-[700px] absolute z-10 flex justify-center items-center">
+        {uploadCover === "" && galleryCover === "" ? (
+          <div className="scale-[0.25] sm:scale-50 md:scale-100 absolute z-10 -mt-14">
             <img src="/assets/empty-img.png" />
           </div>
-        ) : null} */}
+        ) : null}
+      </div>
+      <div className="w-[85%] md:w-[70%] m-auto -mt-[220px] xs:w-[90%] xs:pt-[136px]">
         <input
-          className="w-[85%] sm:w-[80%] md:w-[70%] sm:py-1.5 text-[24px] sm:text-2xl md:text-[46px] xs:text-xl font-bold z-40 absolute bg-transparent mt-6 sm:mt-1 md:-mt-10 placeholder:text-white focus:outline-0"
+          className="w-full relative sm:py-1.5 text-[24px] sm:text-2xl md:text-[46px] xs:text-xl font-bold z-40 bg-transparent placeholder:text-white focus:outline-0"
           placeholder="여기에 제목을 입력해주세요."
-          maxLength={38}
+          maxLength={32}
           autoFocus={true}
           value={courseTitle}
           ref={titleRef}
@@ -90,10 +92,17 @@ const PostInfo = ({
             setCourseTitle(event.target.value);
           }}
         />
-        <p className="sm:mt-[50px] md:mt-[40px] z-20 absolute text-[14px] sm:text-lg hidden xs:hidden sm:flex">
-          {authService.currentUser?.displayName}님만의 여정을 직접 그려보세요!
-        </p>
-        <div className="flex mt-16 sm:mt-[80px] xs:mt-[54px]">
+        <div className="flex justify-between">
+          <p className="z-20 text-[14px] sm:text-lg hidden xs:hidden sm:flex">
+            {authService.currentUser?.displayName}님만의 여정을 직접 그려보세요!
+          </p>
+          {courseTitle.length > 32 ? (
+            <p className="text-white text-xl z-20 drop-shadow-xl px-2">
+              제목은 32자 이하로 작성해주세요.
+            </p>
+          ) : null}
+        </div>
+        <div className="flex mt-4 xs:mt-0">
           <button
             onClick={() => setModalOpen(true)}
             className="bg-black px-1 sm:px-2 py-1 mt-2 mr-3 z-20 text-[12px] sm:badge xs:text-[12px] xs:px-2"
@@ -109,7 +118,7 @@ const PostInfo = ({
         </div>
       </div>
       {modalOpen && (
-        <div className="w-[90%] h-[300px] lg:w-[700px] md:h-[300px] bg-white border border-gray-600 absolute sm:translate-x-[5.5%] md:translate-x-[34%] translate-y-[5%] z-[1000] xs:w-[90%] xs:translate-x-[5.5%]">
+        <div className="w-[90%] h-[300px] lg:w-[700px] md:h-[300px] bg-white border border-gray-600 absolute sm:translate-x-[5.5%] md:translate-x-[36%] translate-y-[5%] z-[1000] xs:w-[90%] xs:translate-x-[5.5%]">
           <div className="w-[95%] m-auto py-1 xs:w-[90%]">
             <div className="border-b border-gray-600 mt-10" />
             <GrFormClose
@@ -134,11 +143,16 @@ const PostInfo = ({
               {category === "업로드" ? (
                 <div className="flex flex-col justify-center items-center h-60">
                   <div className="w-40 flex justify-center items-center">
+                    <button className="text-md px-3 py-2 leading-none border border-black text-black hover:bg-gray-100 mt-4 lg:mt-0">
+                      <label htmlFor="changeimg">파일선택</label>
+                    </button>
                     <input
+                      hidden
+                      id="changeimg"
                       type="file"
+                      placeholder="파일선택"
                       ref={coverRef}
                       onChange={uploadCoverImg}
-                      className="w-[50%] text-black text-center"
                     />
                   </div>
                   <p className="text-black mt-3">

--- a/src/components/common/SearchModalAddCourseBtn.tsx
+++ b/src/components/common/SearchModalAddCourseBtn.tsx
@@ -2,7 +2,7 @@ const SearchModalAddCourseBtn = ({ setModalOpen }: any) => {
   return (
     <button
       onClick={() => setModalOpen(true)}
-      className="w-full h-16 bg-white text-black border border-gray-04 text-lg font-bold mb-7 hover:text-white hover:bg-black xs:h-12 xs:text-[16px]"
+      className="w-full h-16 bg-white text-black border border-gray-03 text-lg font-bold mb-7 hover:text-white hover:bg-black xs:h-16 xs:text-[16px]"
     >
       버튼을 눌러서 여행지를 추가해보세요!
     </button>

--- a/src/components/course/CourseHeader.tsx
+++ b/src/components/course/CourseHeader.tsx
@@ -1,3 +1,5 @@
+import styled from "styled-components";
+
 interface CourseProps {
   course: CourseType | undefined;
 }
@@ -12,28 +14,51 @@ const CourseHeader = ({ course }: CourseProps) => {
         />
       </div>
       <div className="w-full h-[220px] -mt-[220px] sm:h-[450px] sm:-mt-[450px] md:h-[700px] md:-mt-[700px] absolute z-10 bg-gradient-to-t from-[#00000060]" />
-      <div className="w-full left-[15%] -mt-52 text-white absolute xs:left-[5%] xs:-mt-20">
-        <div className=" w-full z-20 flex">
-          <h1 className="z-20 text-5xl font-bold leading-tight w-[70%] xs:text-2xl xs:w-[90%]">
-            {course?.title}
-            <span className="ml-1 z-20 text-xs sm:text-lg font-bold text-black bg-white opacity-80 px-2 py-1 sm:h-auto sm:top-0 xs:px-1.5 xs:py-0.5 ">
-              {course?.travelStatus === true ? "여행 후" : "여행 전"}
-            </span>
-          </h1>
-        </div>
-        <div className="mt-4 z-20 body3 sm:text-2xl flex xs:mt-1 text-white">
-          {course?.location.map((location: any) => {
-            return (
-              <p className="pr-2 z-20" key={location}>
-                #{location}
-              </p>
-            );
-          })}{" "}
-          <p className="z-20">코스를 소개해드릴게요!</p>
-        </div>
+      <div className="flex justify-center">
+        <Information
+          className={Number(course?.title.length) > 28 ? "double-line" : ""}
+        >
+          <div className=" w-full z-20 flex">
+            <h1 className="z-20 text-5xl font-bold leading-tight xs:text-2xl xs:w-full xs:-mt-6">
+              {course?.title}
+              <span className="ml-1 z-20 text-xs sm:text-lg font-bold text-black bg-white opacity-80 px-2 py-1 sm:h-auto sm:top-0 xs:px-1.5 xs:py-0.5 ">
+                {course?.travelStatus === true ? "여행 후" : "여행 전"}
+              </span>
+            </h1>
+          </div>
+          <div className="mt-4 z-20 body3 sm:text-2xl flex xs:mt-1 text-white">
+            {course?.location.map((location: any) => {
+              return (
+                <p className="pr-2 z-20" key={location}>
+                  #{location}
+                </p>
+              );
+            })}{" "}
+            <p className="z-20">코스를 소개해드릴게요!</p>
+          </div>
+        </Information>
       </div>
     </>
   );
 };
 
 export default CourseHeader;
+
+const Information = styled.h1`
+  width: 70%;
+  color: white;
+  position: absolute;
+  margin-top: -160px;
+
+  &.double-line {
+    margin-top: -220px;
+  }
+  @media screen and (max-width: 414px) {
+    width: 90%;
+    left: 5%;
+    margin-top: -55px;
+    &.double-line {
+      margin-top: -120px;
+    }
+  }
+`;

--- a/src/components/course/CourseInfo.tsx
+++ b/src/components/course/CourseInfo.tsx
@@ -38,7 +38,7 @@ const ItemCard = styled.div`
   border: 1px solid #cbcdd2;
   margin-bottom: 32px;
   cursor: pointer;
-  padding: 20px;
+  padding: 10px 5px;
   &.clicked {
     background: black;
     color: white;

--- a/src/components/edit/EditCourseMobile.tsx
+++ b/src/components/edit/EditCourseMobile.tsx
@@ -49,7 +49,7 @@ const EditCourseMobile = () => {
               </div>
             </>
           ) : (
-            <h4 className="font-bold text-black text-[17px] mt-[3px]">
+            <h4 className="font-bold text-black text-[18px] mt-[3px]">
               지도에서 여행지를 선택해보세요.
             </h4>
           )}

--- a/src/components/post/PostMobileCourse.tsx
+++ b/src/components/post/PostMobileCourse.tsx
@@ -47,7 +47,7 @@ const PostMobileCourse = () => {
         <>
           {lists.length === 0 ? null : (
             <div className="lg:hidden 3xl:hidden xs:border xs:border-gray-03 xs:p-5 xs:my-8">
-              <span className="text-[20px] font-bold">
+              <span className="text-[18px] font-bold">
                 지도에서 여행지를 선택해보세요.
               </span>
             </div>

--- a/src/hooks/useDelete.ts
+++ b/src/hooks/useDelete.ts
@@ -23,7 +23,6 @@ const useDelete = ({ target, deleteFn }: deleteType) => {
         if (target == "게시물") {
           navigate("/");
         }
-        // navigate("/");
         Swal.fire({
           icon: "success",
           title: `<p style="font-size: 20px;">${target}이 삭제되었습니다.</p>`,

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import {
   useAddCourseMutation,
   useGetCourseQuery,
@@ -13,7 +13,6 @@ import {
   PostTravelStatus,
   PostMobileCourse,
 } from "../components/post/index";
-import { replaceAllData } from "../redux/modules/courseSlice";
 import Swal from "sweetalert2";
 import * as amplitude from "@amplitude/analytics-browser";
 import { logEvent } from "../utils/amplitude";


### PR DESCRIPTION
### PR 타입
UI 변경

### 반영 브랜치
ex) ui/post -> dev

### 변경 사항
**글쓰기 & 수정페이지**
* 헤더 커버 empty 이미지 중앙 고정
* 헤더 커버 상단 좌측 네모 액박 이미지 제거
* 헤더 커버 이미지 업로드시 파일선택 버튼 커스텀
* 제목 글자수 32자 이하로 제한(32자 초과시 제목 아래에 안내 문구 반환)

**상세페이지** 
* 코스 카드 padding 축소
* 제목 28자 초과시 제목 위치 유동적으로 조정