### PR TITLE
fix: 글쓰기 & 수정페이지 - 커버 이미지 업로드 예외 처리

### DIFF
--- a/src/components/common/PostInfo.tsx
+++ b/src/components/common/PostInfo.tsx
@@ -1,9 +1,11 @@
 import { Dispatch, SetStateAction, useRef, useState } from "react";
 import { authService } from "../../utils/firebase";
-import { galleryLists } from "../post/index";
 import { GrFormClose } from "react-icons/gr";
 import styled from "styled-components";
 import { DebouncedFunc } from "lodash";
+import { getStorage, ref } from "firebase/storage";
+import Swal from "sweetalert2";
+import { galleryLists } from ".";
 
 interface PostProps {
   uploadCover: string | undefined;
@@ -27,9 +29,9 @@ const PostInfo = ({
   changeValueHandler,
 }: PostProps) => {
   const [modalOpen, setModalOpen] = useState(false);
-  const [category, setCategory] = useState("업로드");
+  const [category, setCategory] = useState("갤러리");
   const coverRef = useRef<HTMLInputElement>(null);
-  let file: File | null;
+  let file: any;
 
   const selectCategory = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     const eventTarget = e.target as HTMLElement;
@@ -47,10 +49,23 @@ const PostInfo = ({
       file = coverRef.current.files[0];
       const reader = new FileReader();
       reader.readAsDataURL(file);
-      reader.onloadend = () => {
-        setUploadCover(reader.result as SetStateAction<string | undefined>);
-        setModalOpen(false);
-      };
+
+      if (
+        file.type !== "image/jpg" ||
+        file.type !== "image/jpeg" ||
+        file.type !== "image/png" ||
+        file.type !== "image/bmp"
+      ) {
+        Swal.fire({
+          title: `<p style="font-size: 20px;">jpg, png, bmp 이미지만 가능합니다.\n확장자를 다시 한 번 확인해주세요.</p>`,
+          icon: "error",
+        });
+      } else {
+        reader.onloadend = () => {
+          setUploadCover(reader.result as SetStateAction<string | undefined>);
+          setModalOpen(false);
+        };
+      }
     }
   };
 
@@ -124,7 +139,7 @@ const PostInfo = ({
         </div>
       </div>
       {modalOpen && (
-        <div className="w-[90%] h-[300px] lg:w-[700px] md:h-[300px] bg-white border border-gray-600 absolute sm:translate-x-[5.5%] md:translate-x-[36%] translate-y-[5%] z-[1000] xs:w-[90%] xs:translate-x-[5.5%]">
+        <div className="w-[90%] h-[720px] lg:w-[700px] bg-white border border-gray-600 absolute sm:translate-x-[5.5%] md:translate-x-[36%] translate-y-[5%] z-[1000] xs:w-[90%] xs:translate-x-[5.5%]">
           <div className="w-[95%] m-auto py-1 xs:w-[90%]">
             <div className="border-b border-gray-600 mt-10" />
             <GrFormClose
@@ -133,16 +148,16 @@ const PostInfo = ({
             />
             <div className="flex -mt-[26px]">
               <AddCoverCategory
-                onClick={(e) => selectCategory(e)}
-                className={category === "업로드" ? "clicked" : ""}
-              >
-                업로드
-              </AddCoverCategory>
-              <AddCoverCategory
                 onClick={selectCategory}
                 className={category === "갤러리" ? "clicked" : ""}
               >
                 갤러리
+              </AddCoverCategory>
+              <AddCoverCategory
+                onClick={(e) => selectCategory(e)}
+                className={category === "업로드" ? "clicked" : ""}
+              >
+                업로드
               </AddCoverCategory>
             </div>
             <div className="w-full h-full flex flex-col justify-center items-center">
@@ -166,7 +181,7 @@ const PostInfo = ({
                   </p>
                 </div>
               ) : (
-                <div className="overflow-y-scroll max-h-[236px]">
+                <div className="overflow-y-scroll max-h-[660px] xs:h-[60%]">
                   <div className="grid grid-cols-4 gap-3 text-black mt-4 w-full">
                     {galleryLists.map((item: string) => {
                       return (

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -9,6 +9,41 @@ import MobileCourseToggleBtn from "./MobileCourseToggleBtn";
 import PostInfo from "./PostInfo";
 import PostManageBtns from "./PostManageBtns";
 
+const galleryLists = [
+  "https://cdn.pixabay.com/photo/2020/05/21/11/37/road-5200366_1280.jpg",
+  "https://cdn.pixabay.com/photo/2017/06/20/12/07/castle-2422860_1280.jpg",
+  "https://cdn.pixabay.com/photo/2020/02/09/00/21/jusang-joint-4831628_1280.jpg",
+  "https://cdn.pixabay.com/photo/2019/09/26/23/00/han-river-4507176_1280.jpg",
+  "https://cdn.pixabay.com/photo/2020/07/06/22/55/cornus-5378575_1280.jpg",
+  "https://cdn.pixabay.com/photo/2022/08/31/15/07/seoul-7423593_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/04/11/00/04/sea-3309231_1280.jpg",
+  "https://cdn.pixabay.com/photo/2019/09/17/02/20/jeju-4482313_1280.jpg",
+  "https://cdn.pixabay.com/photo/2017/01/17/15/18/haeundae-beach-1987193_1280.jpg",
+  "https://cdn.pixabay.com/photo/2022/04/04/13/54/city-7111380_1280.jpg",
+  "https://cdn.pixabay.com/photo/2015/09/10/14/11/jeju-934479_1280.jpg",
+  "https://cdn.pixabay.com/photo/2017/09/14/06/33/jeju-2748098_1280.jpg",
+  "https://cdn.pixabay.com/photo/2020/05/05/07/52/republic-of-korea-5131925_1280.jpg",
+  "https://cdn.pixabay.com/photo/2022/02/08/06/18/bird-7000837_1280.jpg",
+  "https://cdn.pixabay.com/photo/2021/09/01/14/57/gamcheon-culture-village-6591589_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/09/02/07/07/south-korea-3648252_1280.jpg",
+  "https://cdn.pixabay.com/photo/2017/09/26/17/06/and-thu-2789325_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/08/01/03/40/autumn-leaves-3576458_1280.jpg",
+  "https://cdn.pixabay.com/photo/2020/01/29/09/36/snow-4801975_1280.jpg",
+  "https://cdn.pixabay.com/photo/2015/10/17/15/54/seoul-olympic-park-992727_1280.jpg",
+  "https://cdn.pixabay.com/photo/2016/10/17/07/53/busan-night-scene-1747130_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/08/23/03/26/south-korea-3625168_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/12/31/14/45/bukchon-3905234_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/11/19/15/06/machang-bridge-3825439_1280.jpg",
+  "https://cdn.pixabay.com/photo/2020/03/19/07/37/suwon-4946628_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/11/09/11/04/mars-3804300_1280.jpg",
+  "https://cdn.pixabay.com/photo/2022/01/13/07/06/house-6934544_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/03/25/22/54/scenery-3261087_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/02/20/19/00/top-3168523_1280.jpg",
+  "https://cdn.pixabay.com/photo/2017/10/09/02/45/korea-2832270_1280.jpg",
+  "https://cdn.pixabay.com/photo/2019/02/22/13/10/sunset-4013511_1280.jpg",
+  "https://cdn.pixabay.com/photo/2018/10/10/16/09/persimmon-3737643_1280.jpg",
+];
+
 export {
   SearchModal,
   SearchModalAddCourseBtn,
@@ -20,4 +55,5 @@ export {
   MobileCourseToggleBtn,
   PostInfo,
   PostManageBtns,
+  galleryLists,
 };

--- a/src/components/post/index.ts
+++ b/src/components/post/index.ts
@@ -5,29 +5,6 @@ import PostCategories from "./PostCategories";
 import PostTravelStatus from "./PostTravelStatus";
 import PostMobileCourse from "./PostMobileCourse";
 
-const galleryLists = [
-  "https://cdn.pixabay.com/photo/2020/05/21/11/37/road-5200366_1280.jpg",
-  "https://cdn.pixabay.com/photo/2017/06/20/12/07/castle-2422860_1280.jpg",
-  "https://cdn.pixabay.com/photo/2020/02/09/00/21/jusang-joint-4831628_1280.jpg",
-  "https://cdn.pixabay.com/photo/2019/09/26/23/00/han-river-4507176_1280.jpg",
-  "https://cdn.pixabay.com/photo/2020/07/06/22/55/cornus-5378575_1280.jpg",
-  "https://cdn.pixabay.com/photo/2022/08/31/15/07/seoul-7423593_1280.jpg",
-  "https://cdn.pixabay.com/photo/2018/04/11/00/04/sea-3309231_1280.jpg",
-  "https://cdn.pixabay.com/photo/2019/09/17/02/20/jeju-4482313_1280.jpg",
-  "https://cdn.pixabay.com/photo/2017/01/17/15/18/haeundae-beach-1987193_1280.jpg",
-  "https://cdn.pixabay.com/photo/2022/04/04/13/54/city-7111380_1280.jpg",
-  "https://cdn.pixabay.com/photo/2015/09/10/14/11/jeju-934479_1280.jpg",
-  "https://cdn.pixabay.com/photo/2017/09/14/06/33/jeju-2748098_1280.jpg",
-  "https://cdn.pixabay.com/photo/2020/05/05/07/52/republic-of-korea-5131925_1280.jpg",
-  "https://cdn.pixabay.com/photo/2022/02/08/06/18/bird-7000837_1280.jpg",
-  "https://cdn.pixabay.com/photo/2021/09/01/14/57/gamcheon-culture-village-6591589_1280.jpg",
-  "https://cdn.pixabay.com/photo/2018/09/02/07/07/south-korea-3648252_1280.jpg",
-  "https://cdn.pixabay.com/photo/2017/09/26/17/06/and-thu-2789325_1280.jpg",
-  "https://cdn.pixabay.com/photo/2018/08/01/03/40/autumn-leaves-3576458_1280.jpg",
-  "https://cdn.pixabay.com/photo/2020/01/29/09/36/snow-4801975_1280.jpg",
-  "https://cdn.pixabay.com/photo/2015/10/17/15/54/seoul-olympic-park-992727_1280.jpg",
-];
-
 export {
   PostCourse,
   PostHashTag,
@@ -35,5 +12,4 @@ export {
   PostCategories,
   PostTravelStatus,
   PostMobileCourse,
-  galleryLists,
 };


### PR DESCRIPTION
**PR 타입**
버그 수정

**반영 브랜치**
fix/cover-img

**변경 사항**
글쓰기 & 수정페이지
* 커버에 jpg, bmp, png 외의 이미지 파일 업로드시 안내 모달 반환
* Add Cover 클릭시 갤러리와 업로드 카테고리 순서 변경
* 갤러리에 기본 이미지 추가